### PR TITLE
remove automatic dns validation from certificate

### DIFF
--- a/sadevs_apps/core_resources_stack.py
+++ b/sadevs_apps/core_resources_stack.py
@@ -13,10 +13,9 @@ class CoreResourcesStack(core.Stack):
             self, "HostedZone", zone_name=self._domain_name
         )
 
-        self._certificate = certificate_manager.DnsValidatedCertificate(
+        self._certificate = certificate_manager.Certificate(
             self,
             "sadevs-apps-cert",
-            hosted_zone=self._hosted_zone,
             domain_name=self._domain_name,
             subject_alternative_names=[f"*.{self._domain_name}"],
             validation_method=certificate_manager.ValidationMethod.DNS,


### PR DESCRIPTION
creating a hosted zone and automatically validated certificate at the
same time is problematic. Using a Certificate instead allows us to
deploy the infrastrucure, update the registrar and allow some time to
pass before attempting validation.